### PR TITLE
fix branch on docs URL

### DIFF
--- a/wallabag/README.md
+++ b/wallabag/README.md
@@ -55,7 +55,7 @@ MIT License
 [commits]: https://github.com/coostax/addon-wallabag/commits/main
 [coostax]: https://github.com/coostax
 [contributors]: https://github.com/coostax/addon-wallabag/graphs/contributors
-[docs]: https://github.com/coostax/addon-wallabag/blob/master/wallabag/DOCS.md
+[docs]: https://github.com/coostax/addon-wallabag/blob/main/wallabag/DOCS.md
 [wallabag]: https://wallabag.org/
 [home-assistant]: https://home-assistant.io
 [i386-shield]: https://img.shields.io/badge/i386-yes-green.svg


### PR DESCRIPTION
# Proposed Changes

Fix URL for Docs in Wallabag plugin

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
