### PR TITLE
:tada: Release of add-on Wallabag 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ MIT License
 [firefly-iii-i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
 [firefly-iii-docs]: https://github.com/coostax/addon-firefly-iii/blob/v2.1.3/firefly-iii/DOCS.md
 
-[addon-wallabag]: https://github.com/coostax/addon-wallabag/blob/v0.2.2/README.md
-[wallabag-version-shield]:  https://img.shields.io/badge/version-v0.2.2-blue.svg
+[addon-wallabag]: https://github.com/coostax/addon-wallabag/blob/v0.2.3/README.md
+[wallabag-version-shield]:  https://img.shields.io/badge/version-v0.2.3-blue.svg
 [wallabag-aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [wallabag-amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [wallabag-armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
 [wallabag-armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [wallabag-i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
-[wallabag-docs]: https://github.com/coostax/addon-wallabag/blob/v0.2.2/wallabag/DOCS.md
+[wallabag-docs]: https://github.com/coostax/addon-wallabag/blob/v0.2.3/wallabag/DOCS.md
 
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2022.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2023.svg
 [license-shield]: https://img.shields.io/github/license/coostax/ha-addons.svg

--- a/wallabag/CHANGELOG.md
+++ b/wallabag/CHANGELOG.md
@@ -1,5 +1,5 @@
 # What’s changed
 
-## ⬆️ Update to Wallabag 2.5.1
+## ⬆️ Update to Wallabag 2.5.2
 
-- ⬆️ Update to Wallabag 2.5.1
+- ⬆️ Update to Wallabag 2.5.2

--- a/wallabag/README.md
+++ b/wallabag/README.md
@@ -62,7 +62,7 @@ MIT License
 [issue]: https://github.com/coostax/addon-wallabag/issues
 [keepchangelog]: http://keepachangelog.com/en/1.0.0/
 [license-shield]: https://img.shields.io/github/license/coostax/addon-wallabag.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2022.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2023.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
 [reddit]: https://reddit.com/r/homeassistant
 [releases-shield]: https://img.shields.io/github/release/coostax/addon-wallabag.svg

--- a/wallabag/config.yaml
+++ b/wallabag/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Wallabag
-version: 0.2.2
+version: 0.2.3
 slug: wallabag
 description: A web application allowing you to save web pages for later reading
 url: "https://github.com/coostax/addon-wallabag"


### PR DESCRIPTION
# Proposed Changes

Release add-on version 0.2.3 that updates Wallabag to version 2.5.2

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
